### PR TITLE
remove clever code

### DIFF
--- a/examples/dynamic-components/cyclejs/src/dynamic-component/index.js
+++ b/examples/dynamic-components/cyclejs/src/dynamic-component/index.js
@@ -6,7 +6,7 @@ import styles from './dynamic-component.css';
 export default function DynamicComponent(sources) {
   const seconds$ = Observable.just(Math.ceil(Math.random() * 100))
     .merge(Observable.interval(1000))
-    .scan(seconds => ++seconds);
+    .scan(seconds => seconds + 1);
 
   const vtree$ = seconds$.map(seconds => <div className={styles.container}>
     I count {seconds} seconds.


### PR DESCRIPTION
`seconds++` is clever code and the purpose is better expressed as `seconds + 1`.
